### PR TITLE
Add support for selfclose option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Class
 
 ::
 
-    class xmlformatter.Formatter(compress ::= False, indent ::= 2, indent_char ::= " ", inline ::= True, encoding_input ::= None, encoding_output ::= None, preserve ::= [ ])
+    class xmlformatter.Formatter(compress ::= False, selfclose ::= False, indent ::= 2, indent_char ::= " ", inline ::= True, encoding_input ::= None, encoding_output ::= None, preserve ::= [ ])
 
 The Formatter class can be used to format XML documents in scripts. By default all parts of the XML document will formatted. All descendants of elements listed by preserve are left unformatted. Setting the boolean property compress to True suppresses the indenting given by the indent and indent_char properties. Without a value given to encoding_input xmlformatter trys to determine the encoding from the XML document. On failure it use UTF-8 as default. encoding_output advises xmlformatter to encode the output explicit by the given value. Otherwise xmlformatter use the inpurt encoding. Setting the boolean property inline to False suppresses inline formatting. By default element content will be formatted everywhere - also within mixed content. The following example shows the usage of the xmlfromatter class:
 
@@ -110,6 +110,12 @@ Members
     compress ::= False
 
 Minify the XML document.
+
+::
+
+    selfclose ::= False
+
+Collapse ``<element></element>`` to ``<element/>``.
 
 ::
 
@@ -169,7 +175,7 @@ Cmd
 
 ::
 
-    xmlformat [--preserve "pre,literal"] [--compress] [--indent num] [--indent-char char]
+    xmlformat [--preserve "pre,literal"] [--compress] [--selfclose] [--indent num] [--indent-char char]
               [--overwrite] [--outfile file] [--encoding enc] [--outencoding enc] [--disable-inlineformatting] 
               [--dispable-correction] [--help] < --infile file | file | - >
 

--- a/xmlformatter.py
+++ b/xmlformatter.py
@@ -9,6 +9,7 @@ import xml.parsers.expat
 __version__ = "0.2.0"
 
 DEFAULT_COMPRESS = False
+DEFAULT_SELFCLOSE = False
 DEFAULT_CORRECT = True
 DEFAULT_INDENT = 2
 DEFAULT_INDENT_CHAR = " "
@@ -26,6 +27,7 @@ class Formatter:
         indent=DEFAULT_INDENT,
         preserve=[],
         compress=DEFAULT_COMPRESS,
+        selfclose=DEFAULT_SELFCLOSE,
         indent_char=DEFAULT_INDENT_CHAR,
         encoding_input=DEFAULT_ENCODING_INPUT,
         encoding_output=DEFAULT_ENCODING_OUTPUT,
@@ -34,6 +36,8 @@ class Formatter:
     ):
         # Minify the XML document:
         self.compress = compress
+        # Use self-closing tags
+        self.selfclose = selfclose
         # Correct text nodes
         self.correct = correct
         # Decode the XML document:
@@ -629,7 +633,7 @@ class Formatter:
             str = ""
             # Don't close empty nodes on compression mode:
             if (
-                not self.formatter.compress
+                not (self.formatter.compress or self.formatter.selfclose)
                 or self.list[self.pos - 1].name != "StartElement"
             ):
                 if self.preserve in [0] and self.indent:
@@ -707,7 +711,7 @@ class Formatter:
             str += "<%s" % self.arg[0]
             for attr in sorted(self.arg[1].keys()):
                 str += self.attribute(attr, self.arg[1][attr])
-            if self.list[self.pos + 1].end and self.formatter.compress:
+            if self.list[self.pos + 1].end and (self.formatter.compress or self.formatter.selfclose):
                 str += "/>"
             else:
                 str += ">"
@@ -741,9 +745,10 @@ def cli_usage(msg=""):
     sys.stderr.write(msg + "\n")
     sys.stderr.write(
         'Usage: xmlformat [--preserve "pre,literal"]\
- [--compress] [--indent num] [--indent-char char] [--outfile file]\
- [--encoding enc] [--outencoding enc] [--disable-inlineformatting]\
- [--overwrite] [--disable-correction] [--help] <--infile file | file | - >\n'
+ [--compress] [--selfclose] [--indent num] [--indent-char char]\
+ [--outfile file] [--encoding enc] [--outencoding enc]\
+ [--disable-inlineformatting] [--overwrite] [--disable-correction]\
+ [--help] <--infile file | file | - >\n'
     )
     sys.exit(2)
 
@@ -757,6 +762,7 @@ def cli():
     overwrite = False
     preserve = []
     compress = DEFAULT_COMPRESS
+    selfclose = DEFAULT_SELFCLOSE
     infile = None
     encoding = DEFAULT_ENCODING_INPUT
     outencoding = DEFAULT_ENCODING_OUTPUT
@@ -768,6 +774,7 @@ def cli():
             "",
             [
                 "compress",
+                "selfclose",
                 "disable-correction",
                 "disable-inlineformatting",
                 "encoding=",
@@ -792,6 +799,8 @@ def cli():
             cli_usage()
         elif key in ["--compress"]:
             compress = True
+        elif key in ["--selfclose"]:
+            selfclose = True
         elif key in ["--outfile"]:
             outfile = value
         elif key in ["--infile"]:
@@ -813,6 +822,7 @@ def cli():
             indent=indent,
             preserve=preserve,
             compress=compress,
+            selfclose=selfclose,
             encoding_input=encoding,
             encoding_output=outencoding,
             indent_char=indent_char,


### PR DESCRIPTION
This adds a `--selfclose` option for uncompressed XMLs. 