### PR TITLE
change 'scripts' to 'entry_points'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ setup(
     description = 'Format and compress XML documents',
     long_description = open('README.rst', 'r').read(),
     py_modules = ['xmlformatter'],
-    scripts = ['bin/xmlformat'],
+    entry_points = {
+        'console_scripts': ['xmlformat=xmlformatter:cli'],
+    },
     classifiers = [
      "Programming Language :: Python :: 2",
      "Programming Language :: Python :: 2.6",


### PR DESCRIPTION
Since the xmlformat script does not have a .py file ending it does not
work well on windows.
entry_points = {'console_scripts': [...]} works cross platform.