### PR TITLE
Process all file paths in a loop

### DIFF
--- a/xmlformatter.py
+++ b/xmlformatter.py
@@ -769,7 +769,6 @@ def cli_usage(msg=""):
 
 def cli():
     """ Launch xmlformatter from command line. """
-    res = None
     indent = DEFAULT_INDENT
     indent_char = DEFAULT_INDENT_CHAR
     outfile = None
@@ -853,16 +852,14 @@ def cli():
             correct=correct,
             eof_newline=eof_newline,
         )
-        input_file = None
         if infile:
-            input_file = infile
-            res = formatter.format_file(input_file)
+            save_formatter_result(formatter.format_file(infile), formatter, overwrite, infile, outfile)
         elif len(args) > 0:
             if args[0] == "-":
-                res = formatter.format_string("".join(sys.stdin.readlines()))
+                save_formatter_result(formatter.format_string("".join(sys.stdin.readlines())), formatter, overwrite, None, outfile)
             else:
-                input_file = args[0]
-                res = formatter.format_file(input_file)
+                for input_file in args:
+                    save_formatter_result(formatter.format_file(input_file), formatter, overwrite, input_file, outfile)
 
     except xml.parsers.expat.ExpatError as err:
         cli_usage("XML error: %s" % err)
@@ -871,6 +868,7 @@ def cli():
     except:
         cli_usage("Unkonwn error")
 
+def save_formatter_result(res, formatter, overwrite, input_file, outfile):
     if overwrite:
         formatter.enc_output(input_file, res)
     else:


### PR DESCRIPTION
According to the pre-commit documentation here https://pre-commit.com/#arguments-pattern-in-hooks if multiple files match the pattern they fill be passed as multiple arguments to the hook. Using `input_file = args[0]` has led to some unpredictable behavior that not all files were processed by this hook. It was kind of random and for example just 4 files out of around 30 in total were processed. After removing them another few were formatted and so on.

With this change all files provided to the hook will be formatted. All other cases different than providing multiple paths at once will work the same as previously.