### PR TITLE
Set isfinal to true in XML parser for proper resource cleanup

### DIFF
--- a/xmlformatter.py
+++ b/xmlformatter.py
@@ -98,7 +98,7 @@ class Formatter:
     def format_string(self, xmldoc=""):
         """ Format a XML document given by xmldoc """
         token_list = Formatter.TokenList(self)
-        token_list.parser.Parse(xmldoc)
+        token_list.parser.Parse(xmldoc, True)
         return self.enc_encode(str(token_list))
 
     def format_file(self, file):


### PR DESCRIPTION
### Summary

Set `isfinal=True` in `Parse()` calls to ensure proper resource finalization after parsing.

### Reference:

[Python XML Parser Documentation](https://docs.python.org/3/library/pyexpat.html#xml.parsers.expat.xmlparser.Parse)
