### PR TITLE
Add --selfclose-space option for XHTML-style self-closing tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,12 @@ Collapse ``<element></element>`` to ``<element/>``.
 
 ::
 
+    selfclose_space ::= False
+
+Render self-closing tags with a space before ``/>`` (e.g. ``<element />`` instead of ``<element/>``). Useful for XHTML and .NET/MSBuild config files.
+
+::
+
     correct ::= True
 
 Apply formatting rules to whitespaces.
@@ -201,7 +207,7 @@ Cmd
 
 ::
 
-    xmlformat [--preserve "pre,literal"] [--blanks] [--compress] [--selfclose] [--indent num] [--indent-char char]
+    xmlformat [--preserve "pre,literal"] [--blanks] [--compress] [--selfclose] [--selfclose-space] [--indent num] [--indent-char char]
               [--overwrite] [--outfile file] [--encoding enc] [--outencoding enc] [--disable-inlineformatting] 
               [--disable-correction] [--preserve-attributes] [--encode-attributes] [--help] < --infile file | file | - >
 

--- a/test/t36.xml
+++ b/test/t36.xml
@@ -1,0 +1,1 @@
+<configuration><add key="foo" value="bar"/></configuration>

--- a/test/t36_selfclose.xml
+++ b/test/t36_selfclose.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <add key="foo" value="bar"/>
+</configuration>

--- a/test/t36_selfclose_space.xml
+++ b/test/t36_selfclose_space.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <add key="foo" value="bar" />
+</configuration>

--- a/test/test_xmlformatter.py
+++ b/test/test_xmlformatter.py
@@ -112,6 +112,14 @@ class TestXmlFormatter(unittest.TestCase):
 		self.formatter = xmlformatter.Formatter(preserve_attributes=True)
 		self.assertEqual(self.formatter.format_file("t33.xml"), self.readfile("t33_pretty.xml"))
 
+	def test_selfclose_space(self):
+		# Default selfclose (no space): regression check for unchanged behavior.
+		self.formatter = xmlformatter.Formatter(selfclose=True, indent="4")
+		self.assertEqual(self.formatter.format_file("t36.xml"), self.readfile("t36_selfclose.xml"))
+		# selfclose_space=True renders self-closing tags as `<foo />`.
+		self.formatter = xmlformatter.Formatter(selfclose=True, selfclose_space=True, indent="4")
+		self.assertEqual(self.formatter.format_file("t36.xml"), self.readfile("t36_selfclose_space.xml"))
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/xmlformatter.py
+++ b/xmlformatter.py
@@ -12,6 +12,7 @@ __version__ = "0.2.8"
 DEFAULT_BLANKS = False
 DEFAULT_COMPRESS = False
 DEFAULT_SELFCLOSE = False
+DEFAULT_SELFCLOSE_SPACE = False
 DEFAULT_CORRECT = True
 DEFAULT_INDENT = 2
 DEFAULT_INDENT_CHAR = " "
@@ -33,6 +34,7 @@ class Formatter:
         blanks=DEFAULT_BLANKS,
         compress=DEFAULT_COMPRESS,
         selfclose=DEFAULT_SELFCLOSE,
+        selfclose_space=DEFAULT_SELFCLOSE_SPACE,
         indent_char=DEFAULT_INDENT_CHAR,
         encoding_input=DEFAULT_ENCODING_INPUT,
         encoding_output=DEFAULT_ENCODING_OUTPUT,
@@ -46,6 +48,8 @@ class Formatter:
         self.compress = compress
         # Use self-closing tags
         self.selfclose = selfclose
+        # Render self-closing tags with a space before "/>" (e.g. <foo />)
+        self.selfclose_space = selfclose_space
         # Correct text nodes
         self.correct = correct
         # Decode the XML document:
@@ -744,7 +748,7 @@ class Formatter:
             for attr in att_list:
                 str += self.attribute(attr, self.arg[1][attr])
             if self.list[self.pos + 1].end and (self.formatter.compress or self.formatter.selfclose):
-                str += "/>"
+                str += " />" if self.formatter.selfclose_space else "/>"
             else:
                 str += ">"
             return str
@@ -777,7 +781,7 @@ def cli_usage(msg=""):
     sys.stderr.write(msg + "\n")
     sys.stderr.write(
         'Usage: xmlformat [--preserve "pre,literal"] [--blanks]\
- [--compress] [--selfclose] [--indent num] [--indent-char char]\
+ [--compress] [--selfclose] [--selfclose-space] [--indent num] [--indent-char char]\
  [--outfile file] [--encoding enc] [--outencoding enc]\
  [--disable-inlineformatting] [--overwrite] [--disable-correction]\
  [--eof-newline] [--preserve-attributes] [--encode-attributes]\
@@ -796,6 +800,7 @@ def cli():
     blanks = False
     compress = DEFAULT_COMPRESS
     selfclose = DEFAULT_SELFCLOSE
+    selfclose_space = DEFAULT_SELFCLOSE_SPACE
     infile = None
     encoding = DEFAULT_ENCODING_INPUT
     outencoding = DEFAULT_ENCODING_OUTPUT
@@ -811,6 +816,7 @@ def cli():
             [
                 "compress",
                 "selfclose",
+                "selfclose-space",
                 "disable-correction",
                 "disable-inlineformatting",
                 "encoding=",
@@ -843,6 +849,8 @@ def cli():
             compress = True
         elif key in ["--selfclose"]:
             selfclose = True
+        elif key in ["--selfclose-space"]:
+            selfclose_space = True
         elif key in ["--outfile"]:
             outfile = value
         elif key in ["--infile"]:
@@ -873,6 +881,7 @@ def cli():
             blanks=blanks,
             compress=compress,
             selfclose=selfclose,
+            selfclose_space=selfclose_space,
             encoding_input=encoding,
             encoding_output=outencoding,
             indent_char=indent_char,


### PR DESCRIPTION
Adds an opt-in `selfclose_space` option (and matching `--selfclose-space` command line flag) that renders self-closing tags with a space before `/>`, producing `<foo />` instead of the default `<foo/>`.

This is the canonical XHTML form and is also the form expected by many .NET / MSBuild configuration files (e.g. `<add key="..." value="..." />` in `app.config` / `web.config` / `packages.config`), where the existing unspaced form, while syntactically valid XML, differs from the project convention and produces noisy diffs.

## Example

Input:

```xml
<root><add key="a" value="b"/></root>
```

Before (default, unchanged):

```
$ xmlformat --compress --selfclose in.xml
<root><add key="a" value="b"/></root>
```

After (new flag):

```
$ xmlformat --compress --selfclose --selfclose-space in.xml
<root><add key="a" value="b" /></root>
```

Equivalent Python API:

```python
import xmlformatter
xmlformatter.Formatter(selfclose=True, selfclose_space=True).format_string(xml)
```